### PR TITLE
Fix issue creation by seeding default project in database

### DIFF
--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -104,6 +104,17 @@ class Database {
                     created_at: new Date().toISOString(),
                     updated_at: new Date().toISOString(),
                 });
+
+                // Seed default project
+                const projectsStore = transaction.objectStore('projects');
+                projectsStore.add({
+                    name: 'HomeSprint',
+                    key: 'HOME',
+                    description: 'Family task management and household operations',
+                    created_by: 1,
+                    created_at: new Date().toISOString(),
+                    updated_at: new Date().toISOString(),
+                });
             };
         });
 


### PR DESCRIPTION
Problem:
- Issue creation was failing with "Project with id 1 not found"
- Database was seeding users and issue types but missing projects

Solution:
- Added default project seeding in database initialization
- Project "HomeSprint" (key: HOME) is now created on first run
- Issue creation now works properly as it can find the default project

Changes:
- src/lib/database.ts: Added project seeding in onupgradeneeded
- Seeds project with id:1, name:"HomeSprint", key:"HOME"

This fixes the "failed to create issue" error reported by the user.

Build Status: ✅ Production build succeeds